### PR TITLE
Update touchnode to use object due to deprecation in Gatsby v2

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -31,7 +31,7 @@ const downloadImageAndCreateFileNode = async (
 
   if (cacheMediaData) {
     fileNodeID = cacheMediaData.fileNodeID
-    touchNode(fileNodeID)
+    touchNode({ nodeId: fileNodeID })
     return fileNodeID
   }
 


### PR DESCRIPTION
See https://next.gatsbyjs.org/docs/actions/#touchNode

**Note:** The plugin still works, it just spits out a bunch of deprecation warnings.

```
Calling "touchNode" with a nodeId is deprecated. Please pass an object containing a nodeId instead: touchNode({ nodeId: 'a-node-id' })
"touchNode" was called by gatsby-source-shopify
Calling "touchNode" with a nodeId is deprecated. Please pass an object containing a nodeId instead: touchNode({ nodeId: 'a-node-id' })
```

I'm guessing this would break v1 compatibility? Not sure if there's a more graceful way to support v1 or if plugins will simply stop supporting Gatsby v1
