### PR TITLE
Fix: add missing field 'availableForSale' on Products

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -117,6 +117,7 @@ export const PRODUCTS_QUERY = `
         edges {
           cursor
           node {
+            availableForSale
             createdAt
             description
             descriptionHtml


### PR DESCRIPTION
Hi,

the field "availableForSale" was only implemented on ProductVariants.
This PR adds the field to Products as well in accordance with the Shopify docs:
https://help.shopify.com/en/api/custom-storefronts/storefront-api/reference/object/product#fields

Thanks!
Julian